### PR TITLE
pip-compile upgrade

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,4 +1,4 @@
 -r requirements.in
-pytest
+pytest<9
 pytest-asyncio
 pytest-jupyterhub

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -145,7 +145,7 @@ pygments==2.19.2
     # via
     #   nbconvert
     #   pytest
-pytest==9.0.1
+pytest==8.4.2
     # via
     #   -r requirements-dev.in
     #   pytest-asyncio

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,51 +4,53 @@
 #
 #    pip-compile requirements-dev.in
 #
-alembic==1.16.3
+alembic==1.17.2
     # via jupyterhub
 annotated-types==0.7.0
     # via pydantic
-anyio==4.9.0
+anyio==4.12.0
     # via jupyter-server
 argon2-cffi==25.1.0
     # via jupyter-server
-argon2-cffi-bindings==21.2.0
+argon2-cffi-bindings==25.1.0
     # via argon2-cffi
-arrow==1.3.0
+arrow==1.4.0
     # via isoduration
-attrs==25.3.0
+attrs==25.4.0
     # via
     #   jsonschema
     #   referencing
-beautifulsoup4==4.13.4
+beautifulsoup4==4.14.3
     # via nbconvert
-bleach[css]==6.2.0
+bleach[css]==6.3.0
     # via nbconvert
-certifi==2025.7.9
+certifi==2025.11.12
     # via requests
 certipy==0.2.2
     # via jupyterhub
-cffi==1.17.1
+cffi==2.0.0
     # via
     #   argon2-cffi-bindings
     #   cryptography
-charset-normalizer==3.4.2
+charset-normalizer==3.4.4
     # via requests
-cryptography==45.0.5
+cryptography==46.0.3
     # via certipy
 defusedxml==0.7.1
     # via nbconvert
-fastjsonschema==2.21.1
+fastjsonschema==2.21.2
     # via nbformat
 fqdn==1.5.1
     # via jsonschema
-idna==3.10
+greenlet==3.3.0
+    # via sqlalchemy
+idna==3.11
     # via
     #   anyio
     #   jsonschema
     #   jupyterhub
     #   requests
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via pytest
 isoduration==20.11.0
     # via jsonschema
@@ -59,17 +61,17 @@ jinja2==3.1.6
     #   nbconvert
 jsonpointer==3.0.0
     # via jsonschema
-jsonschema[format-nongpl]==4.24.0
+jsonschema[format-nongpl]==4.25.1
     # via
     #   jupyter-events
     #   nbformat
-jsonschema-specifications==2025.4.1
+jsonschema-specifications==2025.9.1
     # via jsonschema
 jupyter-client==8.6.3
     # via
     #   jupyter-server
     #   nbclient
-jupyter-core==5.8.1
+jupyter-core==5.9.1
     # via
     #   jupyter-client
     #   jupyter-server
@@ -80,24 +82,26 @@ jupyter-events==0.12.0
     # via
     #   jupyter-server
     #   jupyterhub
-jupyter-server==2.16.0
+jupyter-server==2.17.0
     # via pytest-jupyterhub
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterhub==5.3.0
+jupyterhub==5.4.2
     # via
-    #   -r /Users/SPLi/work/jupyterhub-guacamole-handler/requirements.in
+    #   -r requirements.in
     #   pytest-jupyterhub
 jupyterlab-pygments==0.3.0
     # via nbconvert
+lark==1.3.1
+    # via rfc3987-syntax
 mako==1.3.10
     # via alembic
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   jinja2
     #   mako
     #   nbconvert
-mistune==3.1.3
+mistune==3.1.4
     # via nbconvert
 nbclient==0.10.2
     # via nbconvert
@@ -110,8 +114,6 @@ nbformat==5.10.4
     #   nbconvert
 oauthlib==3.3.1
     # via jupyterhub
-overrides==7.7.0
-    # via jupyter-server
 packaging==25.0
     # via
     #   jupyter-events
@@ -123,32 +125,32 @@ pamela==1.2.0
     # via jupyterhub
 pandocfilters==1.5.1
     # via nbconvert
-platformdirs==4.3.8
+platformdirs==4.5.1
     # via jupyter-core
 pluggy==1.6.0
     # via pytest
-prometheus-client==0.22.1
+prometheus-client==0.23.1
     # via
     #   jupyter-server
     #   jupyterhub
 ptyprocess==0.7.0
     # via terminado
-pycparser==2.22
+pycparser==2.23
     # via cffi
-pydantic==2.11.7
+pydantic==2.12.5
     # via jupyterhub
-pydantic-core==2.33.2
+pydantic-core==2.41.5
     # via pydantic
 pygments==2.19.2
     # via
     #   nbconvert
     #   pytest
-pytest==8.4.1
+pytest==9.0.1
     # via
     #   -r requirements-dev.in
     #   pytest-asyncio
     #   pytest-jupyterhub
-pytest-asyncio==1.0.0
+pytest-asyncio==1.3.0
     # via
     #   -r requirements-dev.in
     #   pytest-jupyterhub
@@ -159,20 +161,20 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   jupyter-client
     #   jupyterhub
-python-json-logger==3.3.0
+python-json-logger==4.0.0
     # via jupyter-events
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via jupyter-events
-pyzmq==27.0.0
+pyzmq==27.1.0
     # via
     #   jupyter-client
     #   jupyter-server
-referencing==0.36.2
+referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
     #   jupyter-events
-requests==2.32.4
+requests==2.32.5
     # via jupyterhub
 rfc3339-validator==0.1.4
     # via
@@ -182,7 +184,9 @@ rfc3986-validator==0.1.1
     # via
     #   jsonschema
     #   jupyter-events
-rpds-py==0.26.0
+rfc3987-syntax==1.1.0
+    # via jsonschema
+rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
@@ -192,11 +196,9 @@ six==1.17.0
     # via
     #   python-dateutil
     #   rfc3339-validator
-sniffio==1.3.1
-    # via anyio
-soupsieve==2.7
+soupsieve==2.8
     # via beautifulsoup4
-sqlalchemy==2.0.41
+sqlalchemy==2.0.44
     # via
     #   alembic
     #   jupyterhub
@@ -206,7 +208,7 @@ terminado==0.18.1
     #   jupyter-server-terminals
 tinycss2==1.4.0
     # via bleach
-tornado==6.5.1
+tornado==6.5.2
     # via
     #   jupyter-client
     #   jupyter-server
@@ -222,9 +224,7 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
-types-python-dateutil==2.9.0.20250708
-    # via arrow
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
     #   alembic
     #   beautifulsoup4
@@ -232,17 +232,19 @@ typing-extensions==4.14.1
     #   pydantic-core
     #   sqlalchemy
     #   typing-inspection
-typing-inspection==0.4.1
+typing-inspection==0.4.2
     # via pydantic
+tzdata==2025.2
+    # via arrow
 uri-template==1.3.0
     # via jsonschema
-urllib3==2.5.0
+urllib3==2.6.0
     # via requests
-webcolors==24.11.1
+webcolors==25.10.0
     # via jsonschema
 webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
-websocket-client==1.8.0
+websocket-client==1.9.0
     # via jupyter-server

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,29 +4,31 @@
 #
 #    pip-compile
 #
-alembic==1.16.3
+alembic==1.17.2
     # via jupyterhub
 annotated-types==0.7.0
     # via pydantic
-arrow==1.3.0
+arrow==1.4.0
     # via isoduration
-attrs==25.3.0
+attrs==25.4.0
     # via
     #   jsonschema
     #   referencing
-certifi==2025.7.9
+certifi==2025.11.12
     # via requests
 certipy==0.2.2
     # via jupyterhub
-cffi==1.17.1
+cffi==2.0.0
     # via cryptography
-charset-normalizer==3.4.2
+charset-normalizer==3.4.4
     # via requests
-cryptography==45.0.5
+cryptography==46.0.3
     # via certipy
 fqdn==1.5.1
     # via jsonschema
-idna==3.10
+greenlet==3.3.0
+    # via sqlalchemy
+idna==3.11
     # via
     #   jsonschema
     #   jupyterhub
@@ -37,17 +39,19 @@ jinja2==3.1.6
     # via jupyterhub
 jsonpointer==3.0.0
     # via jsonschema
-jsonschema[format-nongpl]==4.24.0
+jsonschema[format-nongpl]==4.25.1
     # via jupyter-events
-jsonschema-specifications==2025.4.1
+jsonschema-specifications==2025.9.1
     # via jsonschema
 jupyter-events==0.12.0
     # via jupyterhub
-jupyterhub==5.3.0
+jupyterhub==5.4.2
     # via -r requirements.in
+lark==1.3.1
+    # via rfc3987-syntax
 mako==1.3.10
     # via alembic
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   jinja2
     #   mako
@@ -59,28 +63,28 @@ packaging==25.0
     #   jupyterhub
 pamela==1.2.0
     # via jupyterhub
-prometheus-client==0.22.1
+prometheus-client==0.23.1
     # via jupyterhub
-pycparser==2.22
+pycparser==2.23
     # via cffi
-pydantic==2.11.7
+pydantic==2.12.5
     # via jupyterhub
-pydantic-core==2.33.2
+pydantic-core==2.41.5
     # via pydantic
 python-dateutil==2.9.0.post0
     # via
     #   arrow
     #   jupyterhub
-python-json-logger==3.3.0
+python-json-logger==4.0.0
     # via jupyter-events
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via jupyter-events
-referencing==0.36.2
+referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
     #   jupyter-events
-requests==2.32.4
+requests==2.32.5
     # via jupyterhub
 rfc3339-validator==0.1.4
     # via
@@ -90,7 +94,9 @@ rfc3986-validator==0.1.1
     # via
     #   jsonschema
     #   jupyter-events
-rpds-py==0.26.0
+rfc3987-syntax==1.1.0
+    # via jsonschema
+rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
@@ -98,30 +104,30 @@ six==1.17.0
     # via
     #   python-dateutil
     #   rfc3339-validator
-sqlalchemy==2.0.41
+sqlalchemy==2.0.44
     # via
     #   alembic
     #   jupyterhub
-tornado==6.5.1
+tornado==6.5.2
     # via jupyterhub
 traitlets==5.14.3
     # via
     #   jupyter-events
     #   jupyterhub
-types-python-dateutil==2.9.0.20250708
-    # via arrow
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
     #   alembic
     #   pydantic
     #   pydantic-core
     #   sqlalchemy
     #   typing-inspection
-typing-inspection==0.4.1
+typing-inspection==0.4.2
     # via pydantic
+tzdata==2025.2
+    # via arrow
 uri-template==1.3.0
     # via jsonschema
-urllib3==2.5.0
+urllib3==2.6.0
     # via requests
-webcolors==24.11.1
+webcolors==25.10.0
     # via jsonschema


### PR DESCRIPTION
Pins pytest<9 due to
```
==================================== ERRORS ====================================
__________________ ERROR at setup of test_guacamole_handler[] __________________

self = <Coroutine test_guacamole_handler[]>

    def setup(self) -> None:
        runner_fixture_id = f"_{self._loop_scope}_scoped_runner"
        if runner_fixture_id not in self.fixturenames:
            self.fixturenames.append(runner_fixture_id)
>       return super().setup()
               ^^^^^^^^^^^^^^^

/opt/hostedtoolcache/Python/3.13.9/x64/lib/python3.13/site-packages/pytest_asyncio/plugin.py:458: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

fixturedef = <FixtureDef argname='configured_mockhub_instance' scope='function' baseid=''>
request = <SubRequest 'configured_mockhub_instance' for <Coroutine test_guacamole_handler[]>>

    @pytest.hookimpl(wrapper=True)
    def pytest_fixture_setup(fixturedef: FixtureDef, request) -> object | None:
        asyncio_mode = _get_asyncio_mode(request.config)
        if not _is_asyncio_fixture_function(fixturedef.func):
            if asyncio_mode == Mode.STRICT:
                # Ignore async fixtures without explicit asyncio mark in strict mode
                # This applies to pytest_trio fixtures, for example
fixturedef = <FixtureDef argname='configured_mockhub_instance' scope='function' baseid=''>
request = <SubRequest 'configured_mockhub_instance' for <Coroutine test_guacamole_health>>

    @pytest.hookimpl(wrapper=True)
    def pytest_fixture_setup(fixturedef: FixtureDef, request) -> object | None:
        asyncio_mode = _get_asyncio_mode(request.config)
        if not _is_asyncio_fixture_function(fixturedef.func):
            if asyncio_mode == Mode.STRICT:
                # Ignore async fixtures without explicit asyncio mark in strict mode
                # This applies to pytest_trio fixtures, for example
>               return (yield)
                        ^^^^^
E               pytest.PytestRemovedIn9Warning: 'test_guacamole_health' requested an async fixture 'configured_mockhub_instance', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
E               See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture

/opt/hostedtoolcache/Python/3.13.9/x64/lib/python3.13/site-packages/pytest_asyncio/plugin.py:728: PytestRemovedIn9Warning
=========================== short test summary info ============================
ERROR tests/test_guacamole_handler.py::test_guacamole_handler[] - pytest.PytestRemovedIn9Warning: 'test_guacamole_handler[]' requested an async fixture 'configured_mockhub_instance', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
ERROR tests/test_guacamole_handler.py::test_guacamole_handler[name] - pytest.PytestRemovedIn9Warning: 'test_guacamole_handler[name]' requested an async fixture 'configured_mockhub_instance', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
ERROR tests/test_guacamole_handler.py::test_guacamole_health - pytest.PytestRemovedIn9Warning: 'test_guacamole_health' requested an async fixture 'configured_mockhub_instance', with no plugin or hook that handled it. This is usually an error, as pytest does not natively support it. This will turn into an error in pytest 9.
See: https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture
========================= 1 passed, 3 errors in 0.15s ==========================
```